### PR TITLE
Omogočeno prevajanje napisov pod slikami ipd.

### DIFF
--- a/izpit.cls
+++ b/izpit.cls
@@ -99,7 +99,7 @@
 \LoadClass[\@points]{article}
 \@unless{\boolean{@brezpaketov}}{
   \RequirePackage{amsfonts,amsmath}
-  \RequirePackage[slovene]{babel}
+  \RequirePackage[english,slovene]{babel}
   \RequirePackage[\@encoding]{inputenc}
 }
 \RequirePackage{geometry}
@@ -264,6 +264,7 @@
   \@unless{\boolean{@nadaljuj}}{%
     \setcounter{naloga}{0}%
   }%
+  \@sloeng{\selectlanguage{slovene}}{\selectlanguage{english}}
   \@natisniizpit
 }
 


### PR DESCRIPTION
S to spremembo izbira jezika (nastavitev `anglescina`) vpliva na jezik, nastavljen v paketu `babel`, tako da so potem tudi napisi pod slikami, tabelami ipd. ustrezno prevedeni.

Preden pridružim, se priporočam za kako mnenje, če je tako v redu, ali če bo to potencialno kaj podrlo.